### PR TITLE
Made it so that you could add multiple waypoints when clicking on icons

### DIFF
--- a/Carbonite/NxMap.lua
+++ b/Carbonite/NxMap.lua
@@ -3007,7 +3007,7 @@ function Nx.Map:GMenu_OnGoto()
 		local y = icon.Y
 		local name = icon.Tip and Nx.Split ("\n", icon.Tip) or ""
 
-		self:SetTarget ("Goto", x, y, x, y, false, 0, name)
+		self:SetTarget ("Goto", x, y, x, y, false, 0, name, IsShiftKeyDown())
 	end
 end
 


### PR DESCRIPTION
This will allow you to hold "shift" when clicking on icons on the map, such as those added by HandyNotes, so that you can set multiple waypoints on these icons.