### PR TITLE
Fix for quest detail texture and green quest blobs.

### DIFF
--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -1,4 +1,4 @@
-﻿---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
 -- NxQuest - Quest stuff
 -- Copyright 2007-2012 Carbon Based Creations, LLC
 ---------------------------------------------------------------------------------------
@@ -5275,7 +5275,7 @@ function Nx.Quest.List:Open()
 	f:SetFontObject ("NxFontS")
 
 	local t = f:CreateTexture()
-	t:SetTexture (.1, .2, .3, 1)
+	t:SetColorTexture (.1, .2, .3, 1)
 	t:SetAllPoints (f)
 	f.texture = t
 
@@ -5451,8 +5451,10 @@ function Nx.Quest.List:Open()
 	f:EnableMouse (true)	
 	f:SetFrameStrata ("MEDIUM")	
 	local t = f:CreateTexture()
-	t:SetTexture ("Interface\\QuestFrame\\QuestBG",true)
-	t:SetAllPoints (f)
+	t:SetTexture ("Interface\\QuestFrame\\QuestBG", true, true)
+	--t:SetAllPoints (f)
+	t:SetInside()
+	t:SetTexCoord(0, .585, 0.02, .655)
 	f.texture = t
 
 	f:Show()
@@ -5481,7 +5483,7 @@ function Nx.Quest.List:Open()
 --	win:Attach (qdf, 0, 1, .6, 1)
 --[[
 	local t = qdf:CreateTexture()
-	t:SetTexture (.7, .7, .5, .7)
+	t:SetColorTexture (.7, .7, .5, .7)
 	t:SetAllPoints (qdf)
 	qdf.texture = t
 --]]
@@ -7629,11 +7631,11 @@ function Nx.Quest:UpdateIcons (map)
 											f.NxTip = tip
 
 											if hover then
-												f.texture:SetTexture (hovR, hovG, hovB, hovA)
+												f.texture:SetColorTexture (hovR, hovG, hovB, hovA)
 											elseif tracking then
-												f.texture:SetTexture (trkR, trkG, trkB, trkA)
+												f.texture:SetColorTexture (trkR, trkG, trkB, trkA)
 											else
-												f.texture:SetTexture (r, g, b, col[4])
+												f.texture:SetColorTexture (r, g, b, col[4])
 											end
 										end
 


### PR DESCRIPTION
I think i got some good fixes here. 

Some tip for us, we HAVE to change all SetTexture with solid colors to SetColorTexture in all Carbonite filles. Thats SetTexture(number, number, number[, number]) to SetColorTexture (number, number, number[, number])

This was change in WOW API 7.0.3:
*The Texture method Texture:SetTexture(R, G, B[, A]) no longer works properly in many cases. Use the new method Texture:SetColorTexture instead.*

So if any one has time to change that in all Carbonite lua files that whould be great.