### PR TITLE
Fix for some green areas/quest blobs, fix for quest detail texture (background).

### DIFF
--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -1,4 +1,4 @@
-﻿---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
 -- NxQuest - Quest stuff
 -- Copyright 2007-2012 Carbon Based Creations, LLC
 ---------------------------------------------------------------------------------------
@@ -5275,7 +5275,7 @@ function Nx.Quest.List:Open()
 	f:SetFontObject ("NxFontS")
 
 	local t = f:CreateTexture()
-	t:SetTexture (.1, .2, .3, 1)
+	t:SetColorTexture (.1, .2, .3, 1)
 	t:SetAllPoints (f)
 	f.texture = t
 
@@ -5451,8 +5451,10 @@ function Nx.Quest.List:Open()
 	f:EnableMouse (true)	
 	f:SetFrameStrata ("MEDIUM")	
 	local t = f:CreateTexture()
-	t:SetTexture ("Interface\\QuestFrame\\QuestBG",true)
-	t:SetAllPoints (f)
+	t:SetTexture ("Interface\\QuestFrame\\QuestBG", true, true)
+	--t:SetAllPoints (f)
+	t:SetInside()
+	t:SetTexCoord(0, .585, 0.02, .655)
 	f.texture = t
 
 	f:Show()
@@ -5481,7 +5483,7 @@ function Nx.Quest.List:Open()
 --	win:Attach (qdf, 0, 1, .6, 1)
 --[[
 	local t = qdf:CreateTexture()
-	t:SetTexture (.7, .7, .5, .7)
+	t:SetColorTexture (.7, .7, .5, .7)
 	t:SetAllPoints (qdf)
 	qdf.texture = t
 --]]
@@ -7629,11 +7631,11 @@ function Nx.Quest:UpdateIcons (map)
 											f.NxTip = tip
 
 											if hover then
-												f.texture:SetTexture (hovR, hovG, hovB, hovA)
+												f.texture:SetColorTexture (hovR, hovG, hovB, hovA)
 											elseif tracking then
-												f.texture:SetTexture (trkR, trkG, trkB, trkA)
+												f.texture:SetColorTexture (trkR, trkG, trkB, trkA)
 											else
-												f.texture:SetTexture (r, g, b, col[4])
+												f.texture:SetColorTexture (r, g, b, col[4])
 											end
 										end
 

--- a/Carbonite.Social/NxSocial.lua
+++ b/Carbonite.Social/NxSocial.lua
@@ -1014,7 +1014,7 @@ function Nx.Social.List:Create()
 	f:SetFrameStrata ("MEDIUM")
 
 	local t = f:CreateTexture()
-	t:SetTexture (.2, .2, .2, .5)
+	t:SetColorTexture (.2, .2, .2, .5)
 	t:SetAllPoints (f)
 	f.texture = t
 
@@ -2144,7 +2144,7 @@ function Nx.Social.PunksHUD:Create()
 		but:RegisterForClicks ("LeftButtonDown", "RightButtonDown")
 
 		local t = but:CreateTexture()
-		t:SetTexture (1, 1, 1, 1)
+		t:SetColorTexture (1, 1, 1, 1)
 		t:SetAllPoints (but)
 		but.texture = t
 
@@ -2416,7 +2416,7 @@ function Nx.Social.TeamHUD:Create()
 		but:RegisterForClicks ("LeftButtonDown", "RightButtonDown")
 
 		local t = but:CreateTexture()
-		t:SetTexture (0, .1, 0, .9)
+		t:SetColorTexture (0, .1, 0, .9)
 		t:SetAllPoints (but)
 		but.texture = t
 
@@ -2429,7 +2429,7 @@ function Nx.Social.TeamHUD:Create()
 		f:SetPoint ("TOPLEFT", 0, 0)
 
 		local t = f:CreateTexture()
---		t:SetTexture (0, .1, 0, .4)
+--		t:SetColorTexture (0, .1, 0, .4)
 		t:SetAllPoints (f)
 		f.texture = t
 
@@ -2605,7 +2605,7 @@ function Nx.Social.TeamHUD:Update()
 --	Nx.prt ("%s %s", h, per)
 	local f = self.HealthFrms[1]
 	f:SetWidth (per * cw + 1)
-	f.texture:SetTexture (1 - per, per, 0, .5)
+	f.texture:SetColorTexture (1 - per, per, 0, .5)
 
 	local plTarget = UnitName ("target")
 
@@ -2621,7 +2621,7 @@ function Nx.Social.TeamHUD:Update()
 
 			local f = player.HealthFrm
 			f:SetWidth (per * cw + 1)
-			f.texture:SetTexture (.6 - per * .6, per * .6, 0, .7)
+			f.texture:SetColorTexture (.6 - per * .6, per * .6, 0, .7)
 
 			local name = player.Name
 --			local cls = UnitClass (unit) or ""

--- a/Carbonite/Carbonite.lua
+++ b/Carbonite/Carbonite.lua
@@ -2392,7 +2392,7 @@ function Nx.Combat:Open()
 	f:SetFrameStrata ("MEDIUM")
 
 	local t = f:CreateTexture()
-	t:SetTexture (.2, .2, .2, .5)
+	t:SetColorTexture (.2, .2, .2, .5)
 	t:SetAllPoints (f)
 	f.texture = t
 

--- a/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
+++ b/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
@@ -181,7 +181,7 @@ local function Constructor()
 	if IsLegion then
 		scrollbg:SetColorTexture(0, 0, 0, 0.4)
 	else
-		scrollbg:SetTexture(0, 0, 0, 0.4)
+		scrollbg:SetColorTexture(0, 0, 0, 0.4)
 	end
 
 	--Container Support

--- a/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -676,7 +676,7 @@ local function Constructor()
 	if IsLegion then
 		scrollbg:SetColorTexture(0,0,0,0.4)
 	else
-		scrollbg:SetTexture(0,0,0,0.4)
+		scrollbg:SetColorTexture(0,0,0,0.4)
 	end
 
 	local border = CreateFrame("Frame",nil,frame)

--- a/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
+++ b/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
@@ -151,7 +151,7 @@ local function Constructor()
 	if IsLegion then
 		texture:SetColorTexture(1, 1, 1)
 	else
-		texture:SetTexture(1, 1, 1)
+		texture:SetColorTexture(1, 1, 1)
 	end
 	texture:SetPoint("CENTER", colorSwatch)
 	texture:Show()

--- a/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIWidget-DropDown-Items.lua
+++ b/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIWidget-DropDown-Items.lua
@@ -460,7 +460,7 @@ do
 		if IsLegion then
 			line:SetColorTexture(.5, .5, .5)
 		else
-			line:SetTexture(.5, .5, .5)
+			line:SetColorTexture, .5, .5)
 		end
 		line:SetPoint("LEFT", self.frame, "LEFT", 10, 0)
 		line:SetPoint("RIGHT", self.frame, "RIGHT", -10, 0)

--- a/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIWidget-DropDown-Items.lua
+++ b/Carbonite/Libs/AceGUI-3.0/widgets/AceGUIWidget-DropDown-Items.lua
@@ -460,7 +460,7 @@ do
 		if IsLegion then
 			line:SetColorTexture(.5, .5, .5)
 		else
-			line:SetColorTexture, .5, .5)
+			line:SetColorTexture(.5, .5, .5)
 		end
 		line:SetPoint("LEFT", self.frame, "LEFT", 10, 0)
 		line:SetPoint("RIGHT", self.frame, "RIGHT", -10, 0)

--- a/Carbonite/NxCom.lua
+++ b/Carbonite/NxCom.lua
@@ -1744,15 +1744,15 @@ function Nx.Com:UpdatePlyrIcons (info, map, iconName)
 
 					local sc = map.ScaleDraw
 					map:ClipFrameTL (f, wx - 8 / sc, wy - 8 / sc, 14 * per / sc, 1 / sc)
-					f.texture:SetTexture (1, 1, 1, 1)
+					f.texture:SetColorTexture (1, 1, 1, 1)
 
 				else
 					map:ClipFrameW (f, wx, wy, 8, 8, 0)
 
 					if per > 0 then
-						f.texture:SetTexture (1, .1, .1, 1 - per * 2)
+						f.texture:SetColorTexture (1, .1, .1, 1 - per * 2)
 					else
-						f.texture:SetTexture (0, 0, 0, .5)
+						f.texture:SetColorTexture (0, 0, 0, .5)
 					end
 				end
 
@@ -1768,20 +1768,20 @@ function Nx.Com:UpdatePlyrIcons (info, map, iconName)
 					if tt == 1 then
 						-- Horizontal green bar
 						map:ClipFrameTL (f, wx - 8 / sc, wy - 2 / sc, 14 * per / sc, 1 / sc)
-						f.texture:SetTexture (0, 1, 0, 1)
+						f.texture:SetColorTexture (0, 1, 0, 1)
 
 					else	-- Vertical bar
 
 						map:ClipFrameTL (f, wx - 8 / sc, wy - 7 / sc, 1 / sc, 13 * per / sc)
 
 						if tt == 2 then
-							f.texture:SetTexture (redGlow, .1, 0, 1)
+							f.texture:SetColorTexture (redGlow, .1, 0, 1)
 						elseif tt == 3 then
-							f.texture:SetTexture (1, 1, 0, 1)
+							f.texture:SetColorTexture (1, 1, 0, 1)
 						elseif tt == 4 then
-							f.texture:SetTexture (1, .4, 1, 1)
+							f.texture:SetColorTexture (1, .4, 1, 1)
 						else
-							f.texture:SetTexture (.7, .7, 1, 1)
+							f.texture:SetColorTexture (.7, .7, 1, 1)
 						end
 					end
 				end

--- a/Carbonite/NxHUD.lua
+++ b/Carbonite/NxHUD.lua
@@ -107,7 +107,7 @@ function Nx.HUD:Create()
 	local t = but:CreateTexture()
 	t:SetAllPoints (but)
 	t:SetTexture ("Interface\\AddOns\\Carbonite\\Gfx\\Map\\IconCircle")
---	t:SetTexture (1, 1, 1, 1)
+--	t:SetColorTexture (1, 1, 1, 1)
 	but.texture = t
 
 	but:SetWidth (10)

--- a/Carbonite/NxMap.lua
+++ b/Carbonite/NxMap.lua
@@ -620,7 +620,7 @@ function Nx.Map:Create (index)
 	f:SetMinResize (50, 50)
 
 	local t = f:CreateTexture()
-	t:SetTexture (0, 0, 0, .2)
+	t:SetColorTexture (0, 0, 0, .2)
 	t:SetAllPoints (f)
 	f.texture = t
 
@@ -1210,7 +1210,7 @@ function Nx.Map:CreateLocationTip()
 	local t = f:CreateTexture()
 	f.texture = t
 	t:SetAllPoints (f)
-	t:SetTexture (0, 0, 0, .85)
+	t:SetColorTexture (0, 0, 0, .85)
 
 	-- Font strings
 
@@ -1773,7 +1773,7 @@ function Nx.Map:InitFrames()
 	local t = cf:CreateTexture()
 	t:SetAllPoints (cf)
 	cf.texture = t
---	t:SetTexture (.5, .5, .45, .99)
+--	t:SetColorTexture (.5, .5, .45, .99)
 	t:SetTexture ("Interface\\AddOns\\Carbonite\\Gfx\\Map\\HBlend")
 	t:SetVertexColor (1, 1, 1, .7)
 --]]
@@ -4697,7 +4697,7 @@ function Nx.Map:Update (elapsed)
 
 					local f2 = self:GetIcon (0)
 					self:ClipFrameZTLO (f2, pX, pY, sz, sz, -15, -15)
-					f2.texture:SetTexture (0, 0, 0, .35)
+					f2.texture:SetColorTexture (0, 0, 0, .35)
 
 					f2.NXType = 2000
 					f2.NxTip = tip
@@ -4713,14 +4713,14 @@ function Nx.Map:Update (elapsed)
 
 							local f3 = self:GetIconNI (2)
 							self:ClipFrameZTLO (f3, pX, pY, sz * (10 - leftDur) * .1, 3 / self.ScaleDraw, -15, -15)
-							f3.texture:SetTexture (.5, 1, .5, al)
+							f3.texture:SetColorTexture (.5, 1, .5, al)
 
 							local f3 = self:GetIconNI (2)
 							self:ClipFrameZTLO (f3, pX, pY, sz * (10 - leftDur) * .1, 3 / self.ScaleDraw, -15, 12)
-							f3.texture:SetTexture (.5, 1, .5, al)
+							f3.texture:SetColorTexture (.5, 1, .5, al)
 						end
 
---						f2.texture:SetTexture (.5, 1, .5, abs (GetTime() % .6 - .3) / .3 * .7 + .3)
+--						f2.texture:SetColorTexture (.5, 1, .5, abs (GetTime() % .6 - .3) / .3 * .7 + .3)
 					end
 
 					local red = .3
@@ -4760,13 +4760,13 @@ function Nx.Map:Update (elapsed)
 --					Nx.prtCtrl ("I %s %s %s", name, txIndex, iconType or "nil")
 
 					if iconType == 1 then	-- Ally?
-						f2.texture:SetTexture (0, 0, 1, .3)
+						f2.texture:SetColorTexture (0, 0, 1, .3)
 --						Nx.prtCtrl ("Blue")
 					elseif iconType == 2 then	-- Horde?
-						f2.texture:SetTexture (1, 0, 0, .3)
+						f2.texture:SetColorTexture (1, 0, 0, .3)
 --						Nx.prtCtrl ("Red")
 					else
-						f2.texture:SetTexture (0, 0, 0, .3)
+						f2.texture:SetColorTexture (0, 0, 0, .3)
 					end
 
 					f2.NXType = 2000
@@ -4817,7 +4817,7 @@ function Nx.Map:Update (elapsed)
 
 --	for n = 0, 100 do
 --		local f = self:GetIcon()
---		f.texture:SetTexture (1, 1, .5, 1)
+--		f.texture:SetColorTexture (1, 1, .5, 1)
 --		self:ClipFrameZ (f, n, 50, 2, 2)
 --	end
 
@@ -5422,19 +5422,19 @@ function Nx.Map:UpdateGroup (plX, plY)
 					local sc = self.ScaleDraw
 					self:ClipFrameTL (f, wx - 9 / sc, wy - 10 / sc, 16 * per / sc, 1 / sc)
 --					self:ClipFrameZTLO (f, pX, pY, 12 * per / self.ScaleDraw, .9 / self.ScaleDraw, -7, -7)
-					f.texture:SetTexture (1, 1, 1, 1)
+					f.texture:SetColorTexture (1, 1, 1, 1)
 
 				else
 					self:ClipFrameW (f, wx, wy, 7, 7, 0)
 --					self:ClipFrameZ (f, pX, pY, 7, 7, 0)
 
 					if per > 0 then
-						f.texture:SetTexture (1, .1, .1, 1 - per * 2)
+						f.texture:SetColorTexture (1, .1, .1, 1 - per * 2)
 					else
 						if inactive then
-							f.texture:SetTexture (1, 0, 1, .7)	-- Punk
+							f.texture:SetColorTexture (1, 0, 1, .7)	-- Punk
 						else
-							f.texture:SetTexture (0, 0, 0, .5)	-- Dead
+							f.texture:SetColorTexture (0, 0, 0, .5)	-- Dead
 						end
 					end
 				end
@@ -5469,7 +5469,7 @@ function Nx.Map:UpdateGroup (plX, plY)
 
 						-- Horizontal green bar
 						self:ClipFrameTL (f, wx - 9 / sc, wy - 2 / sc, 16 * per / sc, 1 / sc)
-						f.texture:SetTexture (0, 1, 0, 1)
+						f.texture:SetColorTexture (0, 1, 0, 1)
 
 						tStr = format ("\n|cff80ff80%s %d %s %d", tName, tLvl, tCls, th)
 
@@ -5490,14 +5490,14 @@ function Nx.Map:UpdateGroup (plX, plY)
 							tStr = format ("\n|cffffff40%s %d %s %d%%", tName, tLvl, tCls, th)
 
 							if Nx:UnitIsPlusMob (unitTarget) then
-								f.texture:SetTexture (1, .4, 1, 1)
+								f.texture:SetColorTexture (1, .4, 1, 1)
 							else
-								f.texture:SetTexture (1, 1, 0, 1)
+								f.texture:SetColorTexture (1, 1, 0, 1)
 							end
 
 						else
 							tStr = format ("\n|cffc0c0ff%s %d %s %d%%", tName, tLvl, tCls, th)
-							f.texture:SetTexture (.7, .7, 1, 1)
+							f.texture:SetColorTexture (.7, .7, 1, 1)
 						end
 					end
 				end
@@ -6568,14 +6568,14 @@ function Nx.Map:UpdateOverlay (mapId, bright, noUnexplored)
 				if self:ClipFrameTL (f, wx, wy, txFileW * zscale, txFileH * zscale) then
 
 --					if IsShiftKeyDown() then
---						f.texture:SetTexture (1, 0, 0)
+--						f.texture:SetColorTexture (1, 0, 0)
 --					end
 --[[
 					if IsAltKeyDown() then		-- DEBUG!
 						alpha = .2
 					end
 --]]
-					f.texture:SetTexture (mode and txName or txName .. txIndex)
+					f.texture:SetColorTexture (mode and txName or txName .. txIndex)
 					f.texture:SetVertexColor (brt, brt, brt, alpha)					
 --					if IsControlKeyDown() then
 --						Nx.prt ("Overlay %s, %s, %s %s", txName, txIndex, oX, oY)

--- a/Carbonite/NxUI.lua
+++ b/Carbonite/NxUI.lua
@@ -4039,7 +4039,7 @@ function Nx.EditBox:Create (parentFrm, user, func, maxLetters)
 	f:SetFontObject ("NxFontS")
 
 	local t = f:CreateTexture()
-	t:SetTexture (.1, .2, .3, 1)
+	t:SetColorTexture (.1, .2, .3, 1)
 	t:SetAllPoints (f)
 	f.texture = t
 
@@ -4645,7 +4645,7 @@ function Nx.Menu:Update()
 					itemF:SetScript ("OnMouseUp", self.Item_OnMouseUp)
 
 					local t = itemF:CreateTexture()
-					t:SetTexture (1, 1, 1, 1)
+					t:SetColorTexture (1, 1, 1, 1)
 					t:SetAllPoints (itemF)
 					itemF.texture = t
 				end
@@ -4717,7 +4717,7 @@ function Nx.Menu:Update()
 
 						frm.texture = frm:CreateTexture()
 						frm.texture:SetAllPoints (frm)
-						frm.texture:SetTexture (0, 0, 0, .5)
+						frm.texture:SetColorTexture (0, 0, 0, .5)
 					end
 
 					local tfrm = item.SliderThumbFrm
@@ -4732,7 +4732,7 @@ function Nx.Menu:Update()
 
 						tfrm.texture = tfrm:CreateTexture()
 						tfrm.texture:SetAllPoints (tfrm)
-						tfrm.texture:SetTexture (.5, 1, .5, 1)
+						tfrm.texture:SetColorTexture (.5, 1, .5, 1)
 					end
 
 					frm:SetPoint ("TOPLEFT", 12, -itemH - 1)
@@ -5195,7 +5195,7 @@ function Nx.List:Create (saveName, xpos, ypos, width, height, parentFrm, showAll
 
 	frm.texture = frm:CreateTexture()
 	frm.texture:SetAllPoints (frm)
-	frm.texture:SetTexture (0, 0, 0, .3)
+	frm.texture:SetColorTexture (0, 0, 0, .3)
 
 	frm:SetPoint ("TOPLEFT", xpos, ypos)
 	frm:Show()
@@ -5217,7 +5217,7 @@ function Nx.List:Create (saveName, xpos, ypos, width, height, parentFrm, showAll
 
 		hfrm.texture = hfrm:CreateTexture()
 		hfrm.texture:SetAllPoints (hfrm)
-		hfrm.texture:SetTexture (.2, .2, .3, 1)
+		hfrm.texture:SetColorTexture (.2, .2, .3, 1)
 		hfrm:SetPoint ("TOPLEFT", 0, 0)
 		hfrm:Show()
 	end
@@ -5230,7 +5230,7 @@ function Nx.List:Create (saveName, xpos, ypos, width, height, parentFrm, showAll
 
 	sfrm.texture = sfrm:CreateTexture()
 	sfrm.texture:SetAllPoints (sfrm)
-	sfrm.texture:SetTexture (.4, .4, .5, .4)
+	sfrm.texture:SetColorTexture (.4, .4, .5, .4)
 	sfrm.texture:SetBlendMode ("Add")
 
 --	sfrm:SetHeight (inst:GetLineH() + 1)
@@ -7273,7 +7273,7 @@ function Nx.Slider:Create (parentFrm, typ, size, tlOff)
 
 	frm.texture = frm:CreateTexture()
 	frm.texture:SetAllPoints (frm)
-	frm.texture:SetTexture (.3, .3, .4, .6)
+	frm.texture:SetColorTexture (.3, .3, .4, .6)
 
 	frm:SetPoint ("TOPRIGHT", parentFrm, "TOPRIGHT", 0, -tlOff)
 	frm:SetPoint ("BOTTOMRIGHT", parentFrm, "BOTTOMRIGHT", 0, 0)
@@ -7290,7 +7290,7 @@ function Nx.Slider:Create (parentFrm, typ, size, tlOff)
 
 	tfrm.texture = tfrm:CreateTexture()
 	tfrm.texture:SetAllPoints (tfrm)
-	tfrm.texture:SetTexture (.3, .3, .7, .9)
+	tfrm.texture:SetColorTexture (.3, .3, .7, .9)
 
 	tfrm:SetPoint ("TOPLEFT", 1, 1)
 	tfrm:Show()


### PR DESCRIPTION
I think i got some good fixes here. SetTexture(number, number, number[, number]) was replaced by SetColorTexture (number, number, number[, number]).

This was changed in WOW API 7.0.3:
*The Texture method Texture:SetTexture(R, G, B[, A]) no longer works properly in many cases. Use the new method Texture:SetColorTexture instead.*
