### PR TITLE
Map fixpoiprocessing

### DIFF
--- a/Carbonite/NxMap.lua
+++ b/Carbonite/NxMap.lua
@@ -4634,11 +4634,11 @@ function Nx.Map:Update (elapsed)
 		oldLev = oldLev - 4
 		self.Level = self.Level + 16
 	end
-	local name, description, txIndex, pX, pY
+	local type, name, description, txIndex, pX, pY
 	local txX1, txX2, txY1, txY2
 	local poiNum = GetNumMapLandmarks()
 	for i = 1, poiNum do
-		name, desc, txIndex, pX, pY = GetMapLandmarkInfo (i)
+		type, name, desc, txIndex, pX, pY = GetMapLandmarkInfo (i)
 		if pX and txIndex ~= 0 then		-- WotLK has 0 index POIs for named locations
 
 			local tip = name
@@ -5107,19 +5107,16 @@ function Nx.Map:ScanContinents()
 		SetMapZoom (cont)
 		local mapId = Nx.Map.MapZones[0][cont]
 
-		local name, description, txIndex, pX, pY
+		local type, name, description, txIndex, pX, pY
 		local txX1, txX2, txY1, txY2
 		local poiNum = GetNumMapLandmarks()
 
 --		Nx.prt ("poiNum %d", poiNum)
 
 		for n = 1, poiNum do
-			name, desc, txIndex, pX, pY = GetMapLandmarkInfo (n)
-            if not pX then
-				return
-			end
+			type, name, desc, txIndex, pX, pY = GetMapLandmarkInfo (n)
 				
-			if name and not hideT[txIndex] then
+			if pX and name and not hideT[txIndex] then
 
 				local poi = {}
 				tinsert (poiT, poi)

--- a/Carbonite/NxMap.lua
+++ b/Carbonite/NxMap.lua
@@ -4639,10 +4639,7 @@ function Nx.Map:Update (elapsed)
 	local poiNum = GetNumMapLandmarks()
 	for i = 1, poiNum do
 		name, desc, txIndex, pX, pY = GetMapLandmarkInfo (i)
-		if not pX then			
-			return
-		end
-		if txIndex ~= 0 then		-- WotLK has 0 index POIs for named locations
+		if pX and txIndex ~= 0 then		-- WotLK has 0 index POIs for named locations
 
 			local tip = name
 			if desc then


### PR DESCRIPTION
This branch fixes map landmark processing;  firstly it stops aborting the loop on the POIs when no result is returned; rather it continues to the next iteration.

Second, and more importantly, it adjusts for a 7.0 change to wow API that added another return to the head of GetMapLandmarkInfo().
