### PR TITLE
Quest scanning fixes

### DIFF
--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -3752,9 +3752,7 @@ function Nx.Quest:ScanBlizzQuestDataTimer()
 				IS_BACKGROUND_WORLD_CACHING = false
 				return
 			end
-			if mapId ~= curMapId then
-				SetMapByID(mapId)			-- Triggers WORLD_MAP_UPDATE, which calls MapChanged
-			end
+			SetMapByID(mapId)			-- Triggers WORLD_MAP_UPDATE, which calls MapChanged
 			local cont = Nx.Map.MapWorldInfo[mapId].Cont
 			local info = Map.MapInfo[cont]
 			end
@@ -3800,7 +3798,7 @@ function Nx.Quest:ScanBlizzQuestDataZone()
 	local num = QuestMapUpdateAllQuests()		-- Blizz calls these in this order
 	if num > 0 then
 --		QuestPOIUpdateIcons()
-		local mapId = Nx.Map:GetCurrentMapId()
+		local mapId = GetCurrentMapAreaID()
 		if Nx.Map:IsBattleGroundMap(mapId) then
 			return
 		end

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -7487,7 +7487,7 @@ function Nx.Quest:UpdateIcons (map)
 					break
 				end
 
-				local objName, objZone, typ = Nx.Quest:UnpackObjectiveNew (obj[n])
+				local objName, objZone, typ = Nx.Quest:UnpackObjectiveNew (obj)
 
 				if objZone and objZone ~= 9000 then
 
@@ -7519,7 +7519,7 @@ function Nx.Quest:UpdateIcons (map)
 							if cnt > 1 then
 								sz = map:GetWorldZoneScale (mapId) / 10.02 * ptSz
 							end
-							local x, y = Nx.Quest:UnpackLocPtOff (obj[n])
+							local x, y = Nx.Quest:UnpackLocPtOff (obj)
 							local wx, wy = map:GetWorldPos (mapId, x, y)
 
 							local f = map:GetIconStatic (4)


### PR DESCRIPTION
This fixes a number of relatively long-standing issues with scanning map for quest objectives that are not in Carb's quest DB.
Commit messages should be pretty self-explicit